### PR TITLE
Use package namespace for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Tests\\": "tests/"
+      "Revolution\\Socialite\\Amazon\\Tests\\": "tests/"
     }
   },
   "authors": [

--- a/tests/AmazonProviderStub.php
+++ b/tests/AmazonProviderStub.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace Tests;
+namespace Revolution\Socialite\Amazon\Tests;
 
 use Mockery as m;
 use stdClass;

--- a/tests/SocialiteTest.php
+++ b/tests/SocialiteTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Revolution\Socialite\Amazon\Tests;
 
 use Mockery as m;
 

--- a/tests/SocialiteTest.php
+++ b/tests/SocialiteTest.php
@@ -11,6 +11,7 @@ use Illuminate\Http\RedirectResponse;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\User;
 use Revolution\Socialite\Amazon\AmazonProvider;
+use Revolution\Socialite\Amazon\Tests\TestCase;
 
 class SocialiteTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Revolution\Socialite\Amazon\Tests;
 
 use Laravel\Socialite\SocialiteServiceProvider;
 use Revolution\Socialite\Amazon\AmazonServiceProvider;


### PR DESCRIPTION
You are using the `Tests` namespace right now which leads to autocomplete errors in PhpStorm:

<img width="688" alt="Bildschirmfoto 2020-01-10 um 12 00 58" src="https://user-images.githubusercontent.com/1174473/72148360-e3ed8700-33a0-11ea-933f-3e06e91f4263.png">

This pull request changes the namespace of the tests.